### PR TITLE
Fix fix ci

### DIFF
--- a/.github/workflows/cmake_windows.yml
+++ b/.github/workflows/cmake_windows.yml
@@ -11,7 +11,7 @@ jobs:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: windows-latest
+    runs-on: windows-2019
     
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -31,9 +31,9 @@ jobs:
         key: ${{ runner.os }}-wx
 
     - name: Add MSBuild to PATH (Visual Studio 2019)
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.1
       with:
-        vs-version: '[16.4,16.5)'
+        vs-version: '[16.0,17.0)'
     
     - name: Build wxWidgets
       if: steps.cache-wx.outputs.cache-hit != 'true'

--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -30,8 +30,10 @@ jobs:
         path: wxWidgets-3.1.3
         key: ${{ runner.os }}-wx
 
-    - name: Add MSBuild to PATH
+    - name: Add MSBuild to PATH (Visual Studio 2019)
       uses: microsoft/setup-msbuild@v1.0.2
+      with:
+        vs-version: '[16.4,16.5)'
     
     - name: Build wxWidgets
       if: steps.cache-wx.outputs.cache-hit != 'true'


### PR DESCRIPTION
GitHub recently updated the windows-latest configuration to Windows Server 2022, including the Visual Studio 2022 toolchain. Our builds are not yet supporting this toolchain / environment so this PR makes some changes to freeze the Windows version at Windows Server 2019 and the Visual Studio version at 2019 (v16.x)