### PR TITLE
Feature replace wget with curl for mac os

### DIFF
--- a/.github/workflows/cmake_osx.yml
+++ b/.github/workflows/cmake_osx.yml
@@ -33,7 +33,7 @@ jobs:
       if: steps.cache-wx.outputs.cache-hit != 'true'
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: |
-        wget https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.3/wxWidgets-3.1.3.tar.bz2
+        curl https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.3/wxWidgets-3.1.3.tar.bz2 -O -L
         tar -xf wxWidgets-3.1.3.tar.bz2
         cd wxWidgets-3.1.3
         mkdir buildosx

--- a/build/osx/build.sh
+++ b/build/osx/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Install dependencies and build VocalTractLab
-wget https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.3/wxWidgets-3.1.3.tar.bz2
+curl https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.3/wxWidgets-3.1.3.tar.bz2 -O -L
 tar -xf wxWidgets-3.1.3.tar.bz2
 cd wxWidgets-3.1.3
 mkdir buildosx


### PR DESCRIPTION
On macOS, wget is not installed by default but curl is. This PR therefore switches to curl in the build script and CI for macOS to get rid of another external dependency.

Closes  issue #21 